### PR TITLE
Feat backend SpecialitiesController with CRUD Operations

### DIFF
--- a/Backend/API/Controllers/SpecialitiesController.cs
+++ b/Backend/API/Controllers/SpecialitiesController.cs
@@ -1,0 +1,82 @@
+﻿using Application.Contracts.Services;
+using DTOs;
+using DTOs.Speciality;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class SpecialitiesController : ControllerBase
+{
+    private readonly ISpecialityService _specialityService;
+
+    public SpecialitiesController(ISpecialityService specialityService)
+    {
+        _specialityService = specialityService;
+    }
+
+    [HttpGet()]
+    //[Authorize(Roles = "Patient")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetAllSpecialities()
+    {
+        var response = await _specialityService.GetAllSpecialities();
+
+        if (!response.Success)
+        {
+            return NotFound();
+        }
+        return Ok(response);
+    }
+
+    [HttpGet("{id}")]
+    //[Authorize(Roles = "Patient")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> GetSpecialityById(Guid id)
+    {
+        var response = await _specialityService.GetSpecialityById(id);
+
+        if (!response.Success)
+        {
+            return NotFound($"Speciality with Id {id} was not found.");
+        }
+        return Ok(response);
+    }
+
+    [HttpPut("{id}")]
+    [Authorize(Roles = "Admin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> EditSpeciality(Guid id, UpdateSpecialityDto updateRequest)
+    {
+        var response = await _specialityService.UpdateSpeciality(id, updateRequest);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    //[Authorize(Roles = "Admin")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ServiceResponse<bool>>> AddSpeciality(AddSpecialityDto newSpeciality)
+    {
+        var response = await _specialityService.AddSpecialityAsync(newSpeciality);
+
+        if (!response.Success)
+        {
+            return BadRequest(response);
+        }
+
+        return Ok(response);
+    }
+}

--- a/Backend/Core/Application.csproj
+++ b/Backend/Core/Application.csproj
@@ -13,17 +13,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Behaviors\" />
-    <Folder Include="Validators\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Mappings\Mappings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Behaviors\" />
   </ItemGroup>
 
 </Project>

--- a/Backend/Core/Contracts/Persistence/ISpecialityRepository.cs
+++ b/Backend/Core/Contracts/Persistence/ISpecialityRepository.cs
@@ -6,4 +6,5 @@ public interface ISpecialityRepository : IGenericRepository<Speciality>
 {
     Task<Speciality> GetByNameAsync(string description);
     Task<IEnumerable<Speciality>> GetSpecialitiesByIds(IEnumerable<Guid> specialityIds);
+    Task<Speciality?> GetByIdWithHealthCareProviderAsync(Guid id);
 }

--- a/Backend/Core/Contracts/Services/ISpecialityService.cs
+++ b/Backend/Core/Contracts/Services/ISpecialityService.cs
@@ -1,0 +1,13 @@
+﻿using DTOs;
+using DTOs.Speciality;
+using Domain.Entities;
+
+namespace Application.Contracts.Services;
+
+public interface ISpecialityService
+{
+    Task<ServiceResponse<GetSpecialityDto>> GetSpecialityById(Guid id);
+    Task<ServiceResponse<List<GetSpecialitiesDto>>> GetAllSpecialities();
+    Task<ServiceResponse<GetSpecialitiesDto>> AddSpecialityAsync(AddSpecialityDto speciality);
+    Task<ServiceResponse<bool>> UpdateSpeciality(Guid id, UpdateSpecialityDto updateRequest);
+}

--- a/Backend/Core/ServiceExtensions.cs
+++ b/Backend/Core/ServiceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Application.Contracts.Services;
 using Application.Services;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace Application;
 
@@ -11,6 +13,11 @@ public static class ServiceExtensions
         // add services
         services.AddScoped<IPatientService, PatientService>();
         services.AddScoped<IHealthCareProviderService, HealthCareProviderService>();
+        services.AddScoped<ISpecialityService, SpecialityService>();
+
+
+        // FluentValidation configuration
+        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
         return services;
     }

--- a/Backend/Core/Services/SpecialityService.cs
+++ b/Backend/Core/Services/SpecialityService.cs
@@ -1,0 +1,131 @@
+﻿using Application.Contracts.Persistence;
+using Application.Contracts.Services;
+using Application.Validators.Speciality;
+using AutoMapper;
+using Domain.Entities;
+using DTOs;
+using DTOs.Speciality;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Services;
+
+public class SpecialityService : ISpecialityService
+{
+    private readonly ISpecialityRepository _specialityRepository;
+    private readonly IMapper _mapper;
+    private readonly ILogger<PatientService> _logger;
+
+    public SpecialityService(ISpecialityRepository specialityRepository,
+        IMapper mapper,
+        ILogger<PatientService> logger)
+    {
+        _specialityRepository = specialityRepository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<ServiceResponse<GetSpecialitiesDto>> AddSpecialityAsync(AddSpecialityDto specialityDto)
+    {
+        var serviceResponse = new ServiceResponse<GetSpecialitiesDto>();
+
+        var validator = new AddSpecialityValidator();
+        var validationResult = await validator.ValidateAsync(specialityDto);
+        try
+        {
+            if (validationResult.Errors.Count > 0)
+            {
+                serviceResponse.Success = false;
+                serviceResponse.ValidationErrors = new List<string>();
+                foreach (var error in validationResult.Errors)
+                {
+                    serviceResponse.ValidationErrors.Add(error.ErrorMessage);
+                }
+            }
+            if (serviceResponse.Success)
+            {
+                var newSpeciality = _mapper.Map<Speciality>(specialityDto);
+
+                var speciality = await _specialityRepository.AddAsync(newSpeciality);
+                await _specialityRepository.SaveChangesAsync();
+
+                serviceResponse.Data = _mapper.Map<GetSpecialitiesDto>(speciality);
+                serviceResponse.Message = "Speciality added successfully";
+            }
+        }
+        catch (Exception ex)
+        {
+            serviceResponse.Success = false;
+            serviceResponse.Message = ex.Message;
+            _logger.LogError(ex, ex.Message);
+        }
+
+        return serviceResponse;
+    }
+
+    public async Task<ServiceResponse<List<GetSpecialitiesDto>>> GetAllSpecialities()
+    {
+        var serviceResponse = new ServiceResponse<List<GetSpecialitiesDto>>();
+
+        try
+        {
+            var specialities = await _specialityRepository.GetAllAsync();
+            serviceResponse.Data = _mapper.Map<List<GetSpecialitiesDto>>(specialities);
+            serviceResponse.Message = "Get Specialities List";
+        }
+        catch (Exception ex)
+        {
+            serviceResponse.Success = false;
+            serviceResponse.Message = ex.Message;
+            _logger.LogError(ex.Message);
+        }
+
+        return serviceResponse;
+    }
+
+    public async Task<ServiceResponse<GetSpecialityDto>> GetSpecialityById(Guid id)
+    {
+        var serviceResponse = new ServiceResponse<GetSpecialityDto>();
+        try
+        {
+            var speciality = await _specialityRepository.GetByIdWithHealthCareProviderAsync(id);
+
+            serviceResponse.Data = _mapper.Map<GetSpecialityDto>(speciality);
+        }
+        catch (Exception ex)
+        {
+            serviceResponse.Success = false;
+            serviceResponse.Message = ex.Message;
+            _logger.LogError(ex, $"{ex.Message}");
+        }
+        return serviceResponse;
+    }
+
+    public async Task<ServiceResponse<bool>> UpdateSpeciality(Guid id, UpdateSpecialityDto updateRequest)
+    {
+        var serviceResponse = new ServiceResponse<bool>();
+
+        try
+        {
+            var speciality = await _specialityRepository.GetByIdAsync(id);
+
+            if (speciality == null)
+            {
+                throw new Exception($"Speciality with Id '{id}' was not found.");
+            }
+
+            _mapper.Map(updateRequest, speciality);
+
+            await _specialityRepository.SaveChangesAsync();
+
+            serviceResponse.Data = true;
+            serviceResponse.Message = "Patient updated successfully.";
+        }
+        catch (Exception ex)
+        {
+            serviceResponse.Success = false;
+            serviceResponse.Message = ex.Message;
+            _logger.LogError(ex, ex.Message);
+        }
+        return serviceResponse;
+    }
+}

--- a/Backend/Core/Validators/Speciality/AddSpecialityValidator.cs
+++ b/Backend/Core/Validators/Speciality/AddSpecialityValidator.cs
@@ -1,0 +1,14 @@
+﻿using DTOs.Speciality;
+using FluentValidation;
+
+namespace Application.Validators.Speciality;
+
+public class AddSpecialityValidator : AbstractValidator<AddSpecialityDto>
+{
+    public AddSpecialityValidator()
+    {
+        RuleFor(p => p.Description)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .MaximumLength(60).WithMessage("{PropertyName} cannot be more than {MaxLength} characters");
+    }
+}

--- a/Backend/DTOs/ServiceResponse.cs
+++ b/Backend/DTOs/ServiceResponse.cs
@@ -1,9 +1,39 @@
-﻿namespace DTOs
+﻿namespace DTOs;
+
+public class ServiceResponse<T>
 {
-    public class ServiceResponse<T>
+    public T? Data { get; set; }
+    public bool Success { get; set; } = true;
+    public string Message { get; set; } = string.Empty;
+    public List<string>? ValidationErrors { get; set; }
+
+    public ServiceResponse()
     {
-        public T? Data { get; set; }
-        public bool Success { get; set; } = true;
-        public string Message { get; set; } = string.Empty;
+        Success = true;
+    }
+
+    public ServiceResponse(T? data)
+    {
+        Data = data;
+    }
+
+    public ServiceResponse(string message)
+    {
+        Success = true;
+        Message = message;
+    }
+
+    public ServiceResponse(string message, bool success)
+    {
+        Success = success;
+        Message = message;
+    }
+
+    public ServiceResponse(T? data, bool success, string message, List<string>? validationErrors)
+    {
+        Data = data;
+        Success = success;
+        Message = message;
+        ValidationErrors = validationErrors;
     }
 }

--- a/Backend/DTOs/Speciality/AddSpecialityDto.cs
+++ b/Backend/DTOs/Speciality/AddSpecialityDto.cs
@@ -1,0 +1,6 @@
+﻿namespace DTOs.Speciality;
+
+public class AddSpecialityDto
+{
+    public string Description { get; set; } = string.Empty;
+}

--- a/Backend/DTOs/Speciality/GetSpecialitiesDto.cs
+++ b/Backend/DTOs/Speciality/GetSpecialitiesDto.cs
@@ -1,0 +1,7 @@
+﻿namespace DTOs.Speciality;
+
+public class GetSpecialitiesDto
+{
+    public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+}

--- a/Backend/DTOs/Speciality/GetSpecialityDto.cs
+++ b/Backend/DTOs/Speciality/GetSpecialityDto.cs
@@ -1,0 +1,11 @@
+﻿using Domain.Entities;
+
+namespace DTOs.Speciality;
+
+public class GetSpecialityDto
+{
+    //public Guid Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public ICollection<string> HealthCareProviders { get; set; } = new List<string>();
+
+}

--- a/Backend/DTOs/Speciality/UpdateSpecialityDto.cs
+++ b/Backend/DTOs/Speciality/UpdateSpecialityDto.cs
@@ -1,0 +1,6 @@
+﻿namespace DTOs.Speciality;
+
+public class UpdateSpecialityDto
+{
+    public string Description { get; set; } = string.Empty;
+}

--- a/Backend/Infrastructure/Repositories/SpecialityRepository.cs
+++ b/Backend/Infrastructure/Repositories/SpecialityRepository.cs
@@ -24,4 +24,13 @@ public class SpecialityRepository : GenericRepository<Speciality>, ISpecialityRe
             .Where(x => specialityIds.Contains(x.Id))
             .ToListAsync();
     }
+
+    public async Task<Speciality?> GetByIdWithHealthCareProviderAsync(Guid id)
+    {
+        return await _dbContext.Specialities
+                        .Include(hp => hp.HealthCareProviderSpecialities)
+                        .ThenInclude(hps => hps.HealthCareProvider)
+                        .ThenInclude(hp => hp.ApplicationUser)
+                        .FirstOrDefaultAsync(hp => hp.Id == id);
+    }
 }

--- a/Backend/Mappings/Profiles/SpecialityProfile.cs
+++ b/Backend/Mappings/Profiles/SpecialityProfile.cs
@@ -1,0 +1,26 @@
+﻿using AutoMapper;
+using Domain.Entities;
+using DTOs.Speciality;
+
+namespace Mappings.Profiles;
+
+public class SpecialityProfile : Profile
+{
+    public SpecialityProfile()
+    {
+        CreateMap<Speciality, GetSpecialitiesDto>();
+
+        CreateMap<Speciality, GetSpecialityDto>()
+            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
+            .ForMember(dest => dest.HealthCareProviders,
+                opt => opt.MapFrom(src =>
+                src.HealthCareProviderSpecialities.Select(
+                    hps => hps.HealthCareProvider.ApplicationUser.FirstName + " - " +
+                           hps.HealthCareProvider.ApplicationUser.LastName)
+                .ToList()));
+
+        CreateMap<AddSpecialityDto, Speciality>();
+
+        CreateMap<UpdateSpecialityDto, Speciality>();
+    }
+}


### PR DESCRIPTION
# Add SpecialitiesController with CRUD Operations

## Summary

This pull request introduces a new `SpecialitiesController` with the following methods:

- `GetAll`: Retrieves all specialities.
- `GetByIdWithHealthCareProvider`: Retrieves a speciality by its ID along with associated HealthCareProviders.
- `Update` (Role Admin): Updates an existing speciality.
- `Create Speciality` (Role Admin): Creates a new speciality.

## Details

- Implemented `GetAll` to fetch all specialities.
![image](https://github.com/user-attachments/assets/64ed0593-2e81-4e2d-a0f2-d002b7eef89b)

- Implemented `GetByIdWithHealthCareProvider` to fetch a speciality by its ID with associated HealthCareProviders.
![image](https://github.com/user-attachments/assets/631d968e-9957-4f7b-addd-29f689f7870e)

- Added `Update` method, restricted to Admin role, for updating speciality details.
![image](https://github.com/user-attachments/assets/0abcf5d6-28a8-426b-8fdf-9ac3fed16f94)
![image](https://github.com/user-attachments/assets/1d61071a-94f2-4375-9f49-836291259765)

- Added `Create Speciality` method, restricted to Admin role, for adding new specialities.

## Validation

- Utilized FluentValidation for validating the `Create Speciality` request.
![image](https://github.com/user-attachments/assets/caa7514f-9e1c-4e47-bd03-c30f3ec091d6)

