### PR TITLE
Fix Authenticate Status code return

### DIFF
--- a/Backend/API/Controllers/AccountController.cs
+++ b/Backend/API/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Contracts.Services;
+using Application.Exceptions;
 using DTOs.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -27,11 +28,17 @@ public class AccountController : ControllerBase
         try
         {
             var response = await _authenticationService.AuthenticateAsync(request);
-            if (response == null)
-            {
-                return Unauthorized(new { Message = "Authentication failed" });
-            }
             return Ok(response);
+        }
+        catch (UserNotFoundException ex)
+        {
+            //_logger.LogError(ex, "User not found");
+            return NotFound(new { Message = ex.Message });
+        }
+        catch (InvalidCredentialsException ex)
+        {
+            //_logger.LogError(ex, "Invalid credentials");
+            return Unauthorized(new { Message = ex.Message });
         }
         catch (Exception ex)
         {

--- a/Backend/Core/Exceptions/InvalidCredentialsException.cs
+++ b/Backend/Core/Exceptions/InvalidCredentialsException.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.Exceptions;
+
+public class InvalidCredentialsException : Exception
+{
+    public InvalidCredentialsException() : base("The credentials are not valid.") { }
+}

--- a/Backend/Core/Exceptions/UserNotFoundException.cs
+++ b/Backend/Core/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.Exceptions;
+
+public class UserNotFoundException : Exception
+{
+    public UserNotFoundException(string email) : base($"User with email {email} not found.") { }
+}

--- a/Backend/Core/ServiceExtensions.cs
+++ b/Backend/Core/ServiceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Application.Contracts.Services;
 using Application.Services;
+using Application.Validators.Authentication;
 using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
@@ -19,6 +21,8 @@ public static class ServiceExtensions
 
         // FluentValidation configuration
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+        services.AddControllers()
+                .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<AuthenticationRequestValidator>());
 
         return services;
     }

--- a/Backend/Core/Validators/Authentication/AuthenticationRequestValidator.cs
+++ b/Backend/Core/Validators/Authentication/AuthenticationRequestValidator.cs
@@ -1,0 +1,18 @@
+﻿using DTOs.Authentication;
+using FluentValidation;
+
+namespace Application.Validators.Authentication;
+
+public class AuthenticationRequestValidator : AbstractValidator<AuthenticationRequest>
+{
+    public AuthenticationRequestValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .EmailAddress().WithMessage("A valid email is required.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .MinimumLength(6).WithMessage("{PropertyName} must be at least {MinLength} characters long.");
+    }
+}


### PR DESCRIPTION
# Add Validations and Corresponding Status Codes

## Description

This pull request adds FluentValidation rules for email and password and updates the controller to return appropriate status codes. These changes enhance the robustness and user experience of the authentication process.

## Changes Made

### Validation Rules

Added a new `AuthenticationRequestValidator` class to validate email and password fields with the following rules:

- **Email**
  - Must not be empty.
  - Must be a valid email address.
  
- **Password**
  - Must not be empty.
  - Must be at least 6 characters long.

- Field is required:
![image](https://github.com/user-attachments/assets/5e3869a8-0112-45ce-bf6c-4112411c3848)
- The credentials are not valid:
![image](https://github.com/user-attachments/assets/a8896eab-1119-44eb-bdbc-bc347e0c3ab3)
- Login Ok:
![image](https://github.com/user-attachments/assets/e95a8201-025e-434d-ad73-78eaeaad4980)