### PR TITLE
fix: S3FileService constructor for better AWS handling

### DIFF
--- a/Backend/AWS/S3/S3FileService.cs
+++ b/Backend/AWS/S3/S3FileService.cs
@@ -18,14 +18,16 @@ public class S3FileService : IFileService
     {
         _configuration = configuration;
         _bucketName = _configuration["AWS:BucketName"];
-        _s3Client = new AmazonS3Client(
-                          _configuration["AWS:AccessKey"],
-                          _configuration["AWS:SecretKey"],
-                          Amazon.RegionEndpoint.SAEast1
-                        );
-        var awsOptions = configuration.GetAWSOptions();
-        _s3Client = awsOptions.CreateServiceClient<IAmazonS3>();
 
+        var awsAccessKey = _configuration["AWS:AccessKey"];
+        var awsSecretKey = _configuration["AWS:SecretKey"];
+
+        if (string.IsNullOrEmpty(awsAccessKey) || string.IsNullOrEmpty(awsSecretKey))
+        {
+            throw new ArgumentException("AWS credentials are not configured properly.");
+        }
+
+        _s3Client = new AmazonS3Client(awsAccessKey, awsSecretKey, Amazon.RegionEndpoint.SAEast1);
     }
 
     public async Task<ServiceResponse<string>> UploadFileMedicalRecordAsync(IFormFile file, string fileFolder)


### PR DESCRIPTION
This pull request updates the S3FileService class to ensure that it uses explicit AWS credentials for accessing the S3 service. Previously, the service was incorrectly attempting to retrieve IAM security credentials from the EC2 Instance Metadata Service, which caused errors in the production environment.