### PR TITLE
Improve JWT Expiration Error Handling

### DIFF
--- a/Backend/API/JustinaIo.http
+++ b/Backend/API/JustinaIo.http
@@ -1,6 +1,0 @@
-@JustinaIo_HostAddress = http://localhost:5212
-
-GET {{JustinaIo_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/Backend/API/StartupExtensions.cs
+++ b/Backend/API/StartupExtensions.cs
@@ -98,12 +98,11 @@ public static class StartupExtensions
 
             c.OperationFilter<SwaggerAuthorizeCheckOperationFilter>();
 
-
             c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
             {
-                Description = @"JWT Authorization header using the Bearer scheme. \n\n 
+                Description = @"JWT Authorization header using the Bearer scheme. 
                    Enter 'Bearer' [space] and then your token in the text input below.
-                   \n\nExample: 'Bearer 12345abcdef'",
+                   Example: 'Bearer xxxxx.yyyyy.zzzz'",
                 Name = "Authorization",
                 In = ParameterLocation.Header,
                 Type = SecuritySchemeType.Http, //ApiKey

--- a/Backend/Core/Contracts/Services/IHealthCareProviderService.cs
+++ b/Backend/Core/Contracts/Services/IHealthCareProviderService.cs
@@ -1,7 +1,5 @@
 ﻿using DTOs;
 using DTOs.HealthCareProvider;
-using DTOs.Patient;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Application.Contracts.Services;
 

--- a/Backend/Infrastructure/IdentityServiceExtensions.cs
+++ b/Backend/Infrastructure/IdentityServiceExtensions.cs
@@ -37,48 +37,54 @@ public static class IdentityServiceExtensions
             options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
             options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
         })
-            .AddJwtBearer(o =>
+        .AddJwtBearer(options =>
+        {
+            options.RequireHttpsMetadata = false;
+            options.SaveToken = false;
+            options.TokenValidationParameters = new TokenValidationParameters
             {
-                o.RequireHttpsMetadata = false;
-                o.SaveToken = false;
-                o.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuerSigningKey = true,
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ClockSkew = TimeSpan.Zero,
-                    ValidIssuer = configuration["JwtSettings:Issuer"],
-                    ValidAudience = configuration["JwtSettings:Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["JwtSettings:Key"]))
-                };
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ClockSkew = TimeSpan.Zero,
+                ValidIssuer = configuration["JwtSettings:Issuer"],
+                ValidAudience = configuration["JwtSettings:Audience"],
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["JwtSettings:Key"]))
+            };
 
-                o.Events = new JwtBearerEvents()
+            options.Events = new JwtBearerEvents()
+            {
+                OnAuthenticationFailed = context =>
                 {
-                    OnAuthenticationFailed = c =>
+                    if (context.Exception.GetType() == typeof(SecurityTokenExpiredException))
                     {
-                        c.NoResult();
-                        c.Response.StatusCode = 500;
-                        c.Response.ContentType = "text/plain";
-                        return c.Response.WriteAsync(c.Exception.ToString());
-                    },
-                    OnChallenge = context =>
-                    {
-                        context.HandleResponse();
-                        context.Response.StatusCode = 401;
-                        context.Response.ContentType = "application/json";
-                        var result = JsonSerializer.Serialize("401 Not authorized");
-                        return context.Response.WriteAsync(result);
-                    },
-                    OnForbidden = context =>
-                    {
-                        context.Response.StatusCode = 403;
-                        context.Response.ContentType = "application/json";
-                        var result = JsonSerializer.Serialize("403 Not authorized");
-                        return context.Response.WriteAsync(result);
+                        context.Response.Headers.Add("Token-Expired", "true");
                     }
-                };
-            });
+                    return Task.CompletedTask;
+                },
+                OnChallenge = context =>
+                {
+                    context.HandleResponse();
+                    context.Response.StatusCode = 401;
+                    context.Response.ContentType = "application/json";
+
+                    var result = JsonSerializer.Serialize(new
+                    {
+                        error = "Unauthorized",
+                        error_description = context.ErrorDescription
+                    });
+                    return context.Response.WriteAsync(result);
+                },
+                OnForbidden = context =>
+                {
+                    context.Response.StatusCode = 403;
+                    context.Response.ContentType = "application/json";
+                    var result = JsonSerializer.Serialize("403 Not authorized");
+                    return context.Response.WriteAsync(result);
+                }
+            };
+        });
 
         services.AddAuthorization(options =>
         {


### PR DESCRIPTION
# Improve JWT Expiration Error Handling

## Description
This pull request improves the error handling for expired JWT tokens. The changes ensure that a specific error message is returned when a JWT token has expired.

## Changes
- Updated the JWT middleware to catch `SecurityTokenExpiredException`.
- Added a custom error message for expired tokens.

## Testing
- Verified that an expired JWT token returns the appropriate error message.
![image](https://github.com/user-attachments/assets/603c75a8-71b6-4de0-973b-3f79ee661be7)
